### PR TITLE
April 9 refresh

### DIFF
--- a/vcenter/vc_addingviewingclusters.md
+++ b/vcenter/vc_addingviewingclusters.md
@@ -120,7 +120,7 @@ You can choose to use the IBM-provided VMware licenses or Bring Your Own License
 
 ## Procedure
 
-1. Click **Resources** from the left navigation pane.
+1. Click **Deployed Instances** from the left navigation pane.
 2. In the **vCenter Server Instances** table, click the instance to view the clusters in it or to add clusters to it.
 
    **Note**: If you want to add clusters to this instance, ensure that the instance is in the **Ready to Use** status. Otherwise, you cannot add clusters to the instance.

--- a/vcenter/vc_addingviewingclusters.md
+++ b/vcenter/vc_addingviewingclusters.md
@@ -4,7 +4,7 @@ copyright:
 
   years:  2016, 2018
 
-lastupdated: "2018-03-28"
+lastupdated: "2018-04-06"
 
 ---
 
@@ -48,9 +48,9 @@ Table 1. Options for customized Bare Metal Servers
 
 | CPU options        | RAM options       |
 |:------------- |:------------- |
-| Dual Intel Xeon E5-2620 v4 / 16 cores total, 2.10 GHz | 64 GB, 128 GB, 256 GB, 384 GB, 512 GB, 768 GB, 1.5 TB |
-| Dual Intel Xeon E5-2650 v4 / 24 cores total, 2.20 GHz | 64 GB, 128 GB, 256 GB, 384 GB, 512 GB, 768 GB, 1.5 TB |
-| Dual Intel Xeon E5-2690 v4 / 28 cores total, 2.60 GHz | 64 GB, 128 GB, 256 GB, 384 GB, 512 GB, 768 GB, 1.5 TB |
+| Dual Intel Xeon E5-2620 v4 / 16 cores total, 2.10 GHz | 64 GB, 128 GB, 256 GB, 512 GB, 768 GB, 1.5 TB |
+| Dual Intel Xeon E5-2650 v4 / 24 cores total, 2.20 GHz | 64 GB, 128 GB, 256 GB, 512 GB, 768 GB, 1.5 TB |
+| Dual Intel Xeon E5-2690 v4 / 28 cores total, 2.60 GHz | 64 GB, 128 GB, 256 GB, 512 GB, 768 GB, 1.5 TB |
 | Dual Intel Xeon Gold 6140 Processor / 36 cores total, 2.3 GHz | 96 GB, 192 GB, 384 GB, 768 GB, 1.5 TB |
 
 ### Preconfigured
@@ -120,7 +120,7 @@ You can choose to use the IBM-provided VMware licenses or Bring Your Own License
 
 ## Procedure
 
-1. Click **Deployed Instances** from the left navigation pane.
+1. Click **Resources** from the left navigation pane.
 2. In the **vCenter Server Instances** table, click the instance to view the clusters in it or to add clusters to it.
 
    **Note**: If you want to add clusters to this instance, ensure that the instance is in the **Ready to Use** status. Otherwise, you cannot add clusters to the instance.

--- a/vcenter/vc_orderinginstance.md
+++ b/vcenter/vc_orderinginstance.md
@@ -4,7 +4,7 @@ copyright:
 
   years:  2016, 2018
 
-lastupdated: "2018-03-29"
+lastupdated: "2018-04-06"
 
 ---
 
@@ -108,7 +108,7 @@ Table 2. Options for customized Bare Metal Servers
 | Dual Intel Xeon E5-2620 v4 / 16 cores total, 2.10 GHz | 64 GB, 128 GB, 256 GB, 512 GB, 768 GB, 1.5 TB |
 | Dual Intel Xeon E5-2650 v4 / 24 cores total, 2.20 GHz | 64 GB, 128 GB, 256 GB, 512 GB, 768 GB, 1.5 TB |
 | Dual Intel Xeon E5-2690 v4 / 28 cores total, 2.60 GHz | 64 GB, 128 GB, 256 GB, 512 GB, 768 GB, 1.5 TB |
-| Dual Intel Xeon Gold 6140 Processor / 36 cores total, 2.3 GHz | 96 GB, 192 GB, 768 GB, 1.5 TB |
+| Dual Intel Xeon Gold 6140 Processor / 36 cores total, 2.3 GHz | 96 GB, 192 GB, 384 GB, 768 GB, 1.5 TB |
 
 ### Preconfigured
 


### PR DESCRIPTION
Remove 384 GB option for Skylake only per https://github.ibm.com/tornado/tracker/issues/8342